### PR TITLE
Add volume and market cap filters

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,13 @@ def get_high_returns():
         request.json["lag_return"],
         request.json["daily_volume"],
     )
-    df = momentum_scanner_intraday.get_high_returns(dex, lag_return, daily_volume)
+    if "market_cap" in request.json().keys() or "vol_30" in request.json().keys():
+        market_cap, vol_30 = (request.json["market_cap"], request.json["vol_30"])
+        df = momentum_scanner_intraday.get_high_returns(
+            dex, lag_return, daily_volume, vol_30, market_cap
+        )
+    else:
+        df = momentum_scanner_intraday.get_high_returns(dex, lag_return, daily_volume)
     df.dropna(how="all", axis=1, inplace=True)
     return df.to_dict()
 

--- a/gecko.py
+++ b/gecko.py
@@ -34,11 +34,18 @@ def millis_to_datetime(dt_int):
 def market_chart(coin, *, days):
     import pandas as pd
 
+    assert days in (1, 100)
     chart = get(
         "coins", coin, "market_chart", params={"vs_currency": "usd", "days": days}
     )
     prices = [(millis_to_datetime(dt), pr) for dt, pr in chart["prices"]]
-    return pd.DataFrame(prices, columns=["ts", "price"]).set_index("ts")
+    market_caps = [(millis_to_datetime(dt), mc) for dt, mc in chart["market_caps"]]
+    total_volumes = [(millis_to_datetime(dt), tv) for dt, tv in chart["total_volumes"]]
+    pr = pd.DataFrame(prices, columns=["ts", "price"]).set_index("ts")
+    mc = pd.DataFrame(market_caps, columns=["ts", "market_caps"]).set_index("ts")
+    tv = pd.DataFrame(total_volumes, columns=["ts", "total_volumes"]).set_index("ts")
+    df = pd.concat([pr, mc, tv], axis=1)
+    return df
 
 
 def query_coin(coin):


### PR DESCRIPTION
Fixes https://github.com/VolumeFi/paloma/issues/175

gecko.py: add volume and market cap columns to market_chart's returning dataframe

momentum_scanner_intraday: add a new filtering logic to get_high_returns which selects only rows with volume and market cap above input thresholds

app.py: use the marketcap and volume filters if they are in the request