### PR TITLE
Change search token index

### DIFF
--- a/gecko.py
+++ b/gecko.py
@@ -18,6 +18,7 @@ def get(*args, params: dict = {}):
         timeout=10,
     ).json()
     return cache_db.try_cache(path, params, f)
+    #return f() # for testing without DB caching, uncomment this line and comment out the line above 
 
 
 def exchanges(dex):

--- a/metrics.py
+++ b/metrics.py
@@ -46,7 +46,7 @@ def token_technical_indicator_macd(token):
 def find_rets_24h(vols):
     main_tokens = {"binance-usd", "wbnb", "weth"}
     tokens = set(main_tokens)
-    for pair in vols:
+    for pair in vols.index:
         toks = set(pair.split("<>")) - main_tokens
         if len(toks) == 1:
             tokens.update(toks)

--- a/momentum_scanner_intraday.py
+++ b/momentum_scanner_intraday.py
@@ -85,7 +85,7 @@ def get_high_returns(
     df = metrics.add_7drets(df)
     df = add_intraday_rets(df, lag_return)
     df[lag_col] = df[lag_col].apply(lambda x: round(x * 100, 2))
-    df = df[df[lag_col] >= 0]
+    #df = df[df[lag_col] >= 0]
     df = df.sort_values(by=lag_col, ascending=False)
 
     return df


### PR DESCRIPTION
Change the for loop in metrics.find_rets_24h() to be on vols.index instead of vols.

Also drop df[lag_col]>0 filter to make sure there's always tokens showing up